### PR TITLE
expose HttpMux as an http.Handler implementation

### DIFF
--- a/chatsample/main.go
+++ b/chatsample/main.go
@@ -124,6 +124,11 @@ func runHTTPServer(address string, hub signalr.HubInterface) {
 		signalr.Logger(kitlog.NewLogfmtLogger(os.Stderr), true))
 	router := http.NewServeMux()
 	server.MapHTTP(router, "/chat")
+	// if you are using a different mux you can wrap your signalr.Server in a
+	// signalr.HttpMux and bind it to your router explicitly:
+	// serverMux := signalr.NewHTTPMux(server)
+	// router.HandleFunc("/chat/negotiate", serverMux.Negotiate)
+	// router.Handle("/chat'", serverMux)
 	router.Handle("/", http.FileServer(http.Dir("./public")))
 
 	fmt.Printf("Listening for websocket connections on %s\n", address)

--- a/server.go
+++ b/server.go
@@ -74,8 +74,8 @@ func NewServer(ctx context.Context, options ...func(Party) error) (Server, error
 
 // MapHTTP maps the servers hub to an path in an http.ServeMux
 func (s *server) MapHTTP(mux *http.ServeMux, path string) {
-	httpMux := newHTTPMux(s)
-	mux.HandleFunc(fmt.Sprintf("%s/negotiate", path), httpMux.negotiate)
+	httpMux := NewHTTPMux(s)
+	mux.HandleFunc(fmt.Sprintf("%s/negotiate", path), httpMux.Negotiate)
 	mux.Handle(path, httpMux)
 }
 


### PR DESCRIPTION
the `signalr.HttpMux` type already implements the `http.Handler`
interface (with it's single `ServeHTTP` method) and it's
`Negotiate(..)` method implements `http.HandlerFunc`.

given that these two http interfaces seem to be common
building blocks amongst various mux implementations
making this type and func public (exposing them outside
the `signalr` package) provides an alternative way to bind
the `signalr.Server` to the hosting mux

    serverMux := signalr.NewHttpMux(server)

    router := http.NewServerMux()
    router.HandleFunc("/chat/negotiate", serverMux.Negotiate)
    router.Handle("/chat", serverMux)

this reduces the coupling with `http.ServerMux` and makes
it easier to bind our `signalr.Server` with other mux routers
for example:

- [httprouter](https://github.com/julienschmidt/httprouter#why-doesnt-this-work-with-httphandler)
- [gorilla/mux](https://github.com/gorilla/mux#examples)