### PR TITLE
fix: Flaky test "Clients().All() should invoke all clients"

### DIFF
--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -5,17 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"net"
-	"net/http"
 	"nhooyr.io/websocket"
-	"os"
-	"strings"
-	"time"
 )
 
 type addHub struct {
@@ -151,7 +152,7 @@ var _ = Describe("HTTP server", func() {
 			waitForPort(port)
 			handShakeAndCallWebSocketTestServer(port, "")
 			close(done)
-		}, 2.0)
+		}, 5.0)
 	})
 })
 

--- a/hubcontext_test.go
+++ b/hubcontext_test.go
@@ -3,12 +3,13 @@ package signalr
 import (
 	"context"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 type contextHub struct {
@@ -106,6 +107,7 @@ var _ = Describe("HubContext", func() {
 			callCount <- 0
 			done := make(chan bool)
 			go func(conns []*testingConnection, callCount chan int, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[0].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[0].received
@@ -115,6 +117,7 @@ var _ = Describe("HubContext", func() {
 				}
 			}(conns, callCount, done)
 			go func(conns []*testingConnection, callCount chan int, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[1].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[1].received
@@ -124,6 +127,7 @@ var _ = Describe("HubContext", func() {
 				}
 			}(conns, callCount, done)
 			go func(conns []*testingConnection, callCount chan int, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[2].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[2].received
@@ -163,6 +167,7 @@ var _ = Describe("HubContext", func() {
 			callCount := make(chan int, 1)
 			callCount <- 0
 			go func(conns []*testingConnection, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[0].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[0].received
@@ -218,6 +223,7 @@ var _ = Describe("HubContext", func() {
 				}
 			}(conns)
 			go func(conns []*testingConnection, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[2].received
 				Expect(msg).To(BeAssignableToTypeOf(invocationMessage{}))
 				Expect(strings.ToLower(msg.(invocationMessage).Target)).To(Equal("clientfunc"))
@@ -244,6 +250,7 @@ var _ = Describe("HubContext", func() {
 			callCount <- 0
 			done := make(chan bool)
 			go func(conns []*testingConnection) {
+				defer GinkgoRecover()
 				msg := <-conns[0].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[0].received
@@ -257,10 +264,12 @@ var _ = Describe("HubContext", func() {
 				}
 			}(conns)
 			go func(conns []*testingConnection) {
+				defer GinkgoRecover()
 				msg := <-conns[1].received
 				expectInvocation(msg, callCount, done, 2)
 			}(conns)
 			go func(conns []*testingConnection, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[2].received
 				expectInvocation(msg, callCount, done, 2)
 			}(conns, done)
@@ -289,6 +298,7 @@ var _ = Describe("HubContext", func() {
 			callCount <- 0
 			done := make(chan bool)
 			go func(conns []*testingConnection) {
+				defer GinkgoRecover()
 				msg := <-conns[0].received
 				if _, ok := msg.(completionMessage); ok {
 					msg = <-conns[0].received
@@ -302,10 +312,12 @@ var _ = Describe("HubContext", func() {
 				}
 			}(conns)
 			go func(conns []*testingConnection) {
+				defer GinkgoRecover()
 				msg := <-conns[1].received
 				expectInvocation(msg, callCount, done, 1)
 			}(conns)
 			go func(conns []*testingConnection, done chan bool) {
+				defer GinkgoRecover()
 				msg := <-conns[2].received
 				if _, ok := msg.(completionMessage); ok {
 					Fail(fmt.Sprintf("wrong client received %v", msg))

--- a/hubcontext_test.go
+++ b/hubcontext_test.go
@@ -90,16 +90,14 @@ func connectMany() (Server, []*testingConnection) {
 	return server, conns
 }
 
-var _ = Describe("HubContext", func() {
+var _ = FDescribe("HubContext", func() {
 	var server Server
 	var conns []*testingConnection
-	BeforeEach(func(done Done) {
+	BeforeEach(func() {
 		server, conns = connectMany()
-		close(done)
 	})
-	AfterEach(func(done Done) {
+	AfterEach(func() {
 		server.cancel()
-		close(done)
 	})
 	Context("Clients().All()", func() {
 		It("should invoke all clients", func(didIt Done) {
@@ -143,6 +141,19 @@ var _ = Describe("HubContext", func() {
 			}
 			close(didIt)
 		}, 5.0)
+	})
+})
+
+var _ = Describe("HubContext", func() {
+	var server Server
+	var conns []*testingConnection
+	BeforeEach(func(done Done) {
+		server, conns = connectMany()
+		close(done)
+	})
+	AfterEach(func(done Done) {
+		server.cancel()
+		close(done)
 	})
 
 	Context("Clients().Caller()", func() {
@@ -380,7 +391,7 @@ var _ = Describe("Abort()", func() {
 })
 
 func expectInvocation(msg interface{}, callCount chan int, done chan bool, doneCount int) {
-	Expect(msg).To(BeAssignableToTypeOf(invocationMessage{}))
+	Expect(msg).To(BeAssignableToTypeOf(invocationMessage{}), fmt.Sprintf("Expected invocationMessage, got %T %#v", msg, msg))
 	Expect(strings.ToLower(msg.(invocationMessage).Target)).To(Equal("clientfunc"))
 	d := <-callCount
 	d++

--- a/hubcontext_test.go
+++ b/hubcontext_test.go
@@ -90,7 +90,7 @@ func connectMany() (Server, []*testingConnection) {
 	return server, conns
 }
 
-var _ = FDescribe("HubContext", func() {
+var _ = Describe("HubContext", func() {
 	var server Server
 	var conns []*testingConnection
 	BeforeEach(func() {

--- a/streamclient_test.go
+++ b/streamclient_test.go
@@ -2,10 +2,11 @@ package signalr
 
 import (
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"strings"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var clientStreamingInvocationQueue = make(chan string, 20)
@@ -237,13 +238,11 @@ var _ = Describe("ClientStreaming", func() {
 	Describe("Stream invocation with wrong streamId", func() {
 		var server Server
 		var conn *testingConnection
-		BeforeEach(func(done Done) {
+		BeforeEach(func() {
 			server, conn = connect(&clientStreamHub{})
-			close(done)
 		})
-		AfterEach(func(done Done) {
+		AfterEach(func() {
 			server.cancel()
-			close(done)
 		})
 		Context("When invoked by the client with streamIds", func() {
 			It("should be invoked on the server, and receive stream items until the caller sends a completion. Unknown streamIds should be ignored", func(done Done) {
@@ -261,7 +260,7 @@ var _ = Describe("ClientStreaming", func() {
 					select {
 					case <-clientStreamingInvocationQueue:
 						break loop
-					case <-time.After(100 * time.Millisecond):
+					case <-time.After(500 * time.Millisecond):
 						Fail("timed out")
 					}
 				}
@@ -498,13 +497,11 @@ var _ = Describe("ClientStreaming", func() {
 	Describe("Client sending invalid completion", func() {
 		var server Server
 		var conn *testingConnection
-		BeforeEach(func(done Done) {
+		BeforeEach(func() {
 			server, conn = connect(&clientStreamHub{})
-			close(done)
 		})
-		AfterEach(func(done Done) {
+		AfterEach(func() {
 			server.cancel()
-			close(done)
 		})
 		Context("When an invalid completion message with missing id is sent", func() {
 			It("should end the connection with an error", func(done Done) {


### PR DESCRIPTION
Still flaky on the CI build (not on MacOS). Put it an own Describe block with synchronous Before/AfterEach