### PR TITLE
new: Disable logging in signalr tests per default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,3 @@ dist
 /.vscode
 /cover.out
 /coverage.txt
-
-/testLogConf.json

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 /.vscode
 /cover.out
 /coverage.txt
+
+/testLogConf.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Protocol encoding in JSON is fully supported, and there is MessagePack support f
     - [Client side](#client-side)
         - [Grab copies of the signalr scripts](#grab-copies-of-the-signalr-scripts)
         - [Use a HubConnection to connect to your server Hub](#use-a-hubconnection-to-connect-to-your-server-hub)
+- [Debugging](#debugging)
 
 ## Install
 
@@ -224,3 +225,16 @@ How you format your client UI is going to depend on your application use case bu
 </body>
 </html>
 ```
+
+### Debugging
+
+Server, Client and the protocol implementations are able to log most of their operations. The logging option is disabled
+by default in all tests. To configure logging, create a `testLogConf.json` file with this content
+```json
+{
+  "Enabled": false,
+  "Debug": false
+}
+```
+- If `Enabled` is set to `true`, the logging will be enabled. The tests will log to `os.Stderr`
+- If `Debug` ist set to `true`, the logging will be more detailed.

--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ How you format your client UI is going to depend on your application use case bu
 ### Debugging
 
 Server, Client and the protocol implementations are able to log most of their operations. The logging option is disabled
-by default in all tests. To configure logging, create a `testLogConf.json` file with this content
+by default in all tests. To configure logging, edit the `testLogConf.json` file:
 ```json
 {
   "Enabled": false,
   "Debug": false
 }
 ```
-- If `Enabled` is set to `true`, the logging will be enabled. The tests will log to `os.Stderr`
+- If `Enabled` is set to `true`, the logging will be enabled. The tests will log to `os.Stderr`.
 - If `Debug` ist set to `true`, the logging will be more detailed.

--- a/client_test.go
+++ b/client_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io"
-	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -43,7 +41,7 @@ func (pc *pipeConnection) ConnectionID() string {
 	return "X"
 }
 
-func (pc *pipeConnection) SetConnectionID(id string) {}
+func (pc *pipeConnection) SetConnectionID(string) {}
 
 func (pc *pipeConnection) SetTimeout(timeout time.Duration) {
 	pc.timeout = timeout
@@ -119,7 +117,7 @@ var _ = Describe("Client", func() {
 		It("should connect to the server", func(done Done) {
 			// Create a simple server
 			server, err := NewServer(context.TODO(), SimpleHubFactory(&simpleHub{}),
-				Logger(log.NewLogfmtLogger(os.Stderr), false),
+				testLoggerOption(),
 				ChanReceiveTimeout(200*time.Millisecond),
 				StreamBufferCapacity(5))
 			Expect(err).NotTo(HaveOccurred())
@@ -129,7 +127,7 @@ var _ = Describe("Client", func() {
 			// Start the server
 			go server.Serve(srvConn)
 			// Create the Client
-			clientConn, err := NewClient(context.TODO(), cliConn, formatOption)
+			clientConn, err := NewClient(context.TODO(), cliConn, testLoggerOption(), formatOption)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clientConn).NotTo(BeNil())
 			// Start it
@@ -148,7 +146,7 @@ var _ = Describe("Client", func() {
 		var server Server
 		BeforeEach(func(done Done) {
 			server, _ = NewServer(context.TODO(), SimpleHubFactory(&simpleHub{}),
-				Logger(log.NewLogfmtLogger(os.Stderr), false),
+				testLoggerOption(),
 				ChanReceiveTimeout(200*time.Millisecond),
 				StreamBufferCapacity(5))
 			// Create both ends of the connection
@@ -156,7 +154,7 @@ var _ = Describe("Client", func() {
 			// Start the server
 			go server.Serve(srvConn)
 			// Create the Client
-			client, _ = NewClient(context.TODO(), cliConn, Receiver(simpleReceiver{}), formatOption)
+			client, _ = NewClient(context.TODO(), cliConn, Receiver(simpleReceiver{}), testLoggerOption(), formatOption)
 			// Start it
 			_ = client.Start()
 			close(done)
@@ -200,7 +198,7 @@ var _ = Describe("Client", func() {
 		var server Server
 		BeforeEach(func(done Done) {
 			server, _ = NewServer(context.TODO(), SimpleHubFactory(&simpleHub{}),
-				Logger(log.NewLogfmtLogger(os.Stderr), false),
+				testLoggerOption(),
 				ChanReceiveTimeout(200*time.Millisecond),
 				StreamBufferCapacity(5))
 			// Create both ends of the connection
@@ -208,7 +206,7 @@ var _ = Describe("Client", func() {
 			// Start the server
 			go server.Serve(srvConn)
 			// Create the Client
-			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), formatOption)
+			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), testLoggerOption(), formatOption)
 			// Start it
 			_ = client.Start()
 			close(done)
@@ -279,7 +277,7 @@ var _ = Describe("Client", func() {
 		var server Server
 		BeforeEach(func(done Done) {
 			server, _ = NewServer(context.TODO(), SimpleHubFactory(&simpleHub{}),
-				Logger(log.NewLogfmtLogger(os.Stderr), true),
+				testLoggerOption(),
 				ChanReceiveTimeout(200*time.Millisecond),
 				StreamBufferCapacity(5))
 			// Create both ends of the connection
@@ -288,7 +286,7 @@ var _ = Describe("Client", func() {
 			go server.Serve(srvConn)
 			// Create the Client
 			receiver := &simpleReceiver{}
-			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), formatOption)
+			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), testLoggerOption(), formatOption)
 			// Start it
 			_ = client.Start()
 			close(done)
@@ -346,7 +344,7 @@ var _ = Describe("Client", func() {
 		BeforeEach(func(done Done) {
 			hub.receiveStreamDone = make(chan struct{}, 1)
 			server, _ = NewServer(context.TODO(), HubFactory(func() HubInterface { return hub }),
-				Logger(log.NewLogfmtLogger(os.Stderr), false),
+				testLoggerOption(),
 				ChanReceiveTimeout(200*time.Millisecond),
 				StreamBufferCapacity(5))
 			// Create both ends of the connection
@@ -355,7 +353,7 @@ var _ = Describe("Client", func() {
 			go server.Serve(srvConn)
 			// Create the Client
 			receiver := &simpleReceiver{}
-			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), formatOption)
+			client, _ = NewClient(context.TODO(), cliConn, Receiver(receiver), testLoggerOption(), formatOption)
 			// Start it
 			_ = client.Start()
 			close(done)

--- a/connection_test.go
+++ b/connection_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Handshake", func() {
 	var server Server
 	var conn *testingConnection
 	BeforeEach(func(done Done) {
-		server, _ = NewServer(context.TODO(), SimpleHubFactory(&handshakeHub{}))
+		server, _ = NewServer(context.TODO(), SimpleHubFactory(&handshakeHub{}), testLoggerOption())
 		conn = newTestingConnection()
 		go server.Serve(conn)
 		close(done)
@@ -206,7 +206,7 @@ var _ = Describe("Handshake", func() {
 	})
 	Context("When the handshake connection is initiated, but the client does not send a handshake request within the handshake timeout ", func() {
 		It("should not be connected", func(done Done) {
-			server, _ := NewServer(context.TODO(), SimpleHubFactory(&handshakeHub{}), HandshakeTimeout(time.Millisecond*100))
+			server, _ := NewServer(context.TODO(), SimpleHubFactory(&handshakeHub{}), HandshakeTimeout(time.Millisecond*100), testLoggerOption())
 			conn := newTestingConnection()
 			go server.Serve(conn)
 			time.Sleep(time.Millisecond * 200)

--- a/hubcontext_test.go
+++ b/hubcontext_test.go
@@ -3,11 +3,9 @@ package signalr
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -75,7 +73,7 @@ var hubContextInvocationQueue = make(chan string, 10)
 
 func connectMany() (Server, []*testingConnection) {
 	server, err := NewServer(context.TODO(), SimpleHubFactory(&contextHub{}),
-		Logger(log.NewLogfmtLogger(os.Stderr), false))
+		testLoggerOption())
 	if err != nil {
 		Fail(err.Error())
 		return nil, nil
@@ -362,7 +360,7 @@ var _ = Describe("HubContext", func() {
 var _ = Describe("Abort()", func() {
 	It("should abort the connection of the current caller", func(done Done) {
 		server, err := NewServer(context.TODO(), SimpleHubFactory(&contextHub{}),
-			Logger(log.NewLogfmtLogger(os.Stderr), false),
+			testLoggerOption(),
 			ChanReceiveTimeout(200*time.Millisecond),
 			StreamBufferCapacity(5))
 		Expect(err).NotTo(HaveOccurred())

--- a/hubprotocol_test.go
+++ b/hubprotocol_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"io"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -23,7 +21,7 @@ var _ = Describe("Protocol", func() {
 		&messagePackHubProtocol{},
 	} {
 		protocol := p
-		protocol.setDebugLogger(log.NewLogfmtLogger(os.Stderr))
+		protocol.setDebugLogger(testLogger())
 		Describe(fmt.Sprintf("%T: WriteMessage/ParseMessages roundtrip", protocol), func() {
 			Context("InvocationMessage", func() {
 				for _, a := range [][]interface{}{

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,41 @@
+package signalr
+
+import (
+	"encoding/json"
+	"github.com/go-kit/kit/log"
+	"io/ioutil"
+	"os"
+)
+
+type loggerConfig struct {
+	Enabled bool
+	Debug   bool
+}
+
+var lConf loggerConfig
+
+var tLog StructuredLogger
+
+func testLoggerOption() func(Party) error {
+	testLogger()
+	return Logger(tLog, lConf.Debug)
+}
+
+func testLogger() StructuredLogger {
+	if tLog == nil {
+		lConf = loggerConfig{Enabled: false, Debug: false}
+		b, err := ioutil.ReadFile("testLogConf.json")
+		if err == nil {
+			err = json.Unmarshal(b, &lConf)
+			if err != nil {
+				lConf = loggerConfig{Enabled: false, Debug: false}
+			}
+		}
+		writer := ioutil.Discard
+		if lConf.Enabled {
+			writer = os.Stderr
+		}
+		tLog = log.NewLogfmtLogger(writer)
+	}
+	return tLog
+}

--- a/messagepackhubprotocol_test.go
+++ b/messagepackhubprotocol_test.go
@@ -2,16 +2,14 @@ package signalr
 
 import (
 	"bytes"
-	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 	"reflect"
 )
 
 var _ = Describe("MessagePackHubProtocol", func() {
 	protocol := messagePackHubProtocol{}
-	protocol.setDebugLogger(log.NewLogfmtLogger(os.Stderr))
+	protocol.setDebugLogger(testLogger())
 	Context("ParseMessages", func() {
 		It("should encode/decode an InvocationMessage", func() {
 			message := invocationMessage{

--- a/serveroptions_test.go
+++ b/serveroptions_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Server options", func() {
 		})
 		Context("When UseHub is used on a client", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewClient(context.TODO(), newTestingConnection(), UseHub(&singleHub{}))
+				_, err := NewClient(context.TODO(), newTestingConnection(), testLoggerOption(), UseHub(&singleHub{}))
 				Expect(err).To(HaveOccurred())
 				close(done)
 			})
@@ -97,7 +97,7 @@ var _ = Describe("Server options", func() {
 	Describe("SimpleHubFactory option", func() {
 		Context("When the SimpleHubFactory option is used", func() {
 			It("should call the hub factory on each hub method invocation", func(done Done) {
-				server, err := NewServer(context.TODO(), SimpleHubFactory(&singleHub{}))
+				server, err := NewServer(context.TODO(), SimpleHubFactory(&singleHub{}), testLoggerOption())
 				Expect(server).NotTo(BeNil())
 				Expect(err).To(BeNil())
 				conn := newTestingConnectionForServer()
@@ -137,7 +137,7 @@ var _ = Describe("Server options", func() {
 		})
 		Context("When SimpleHubFactory is used on a client", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewClient(context.TODO(), newTestingConnection(), SimpleHubFactory(&singleHub{}))
+				_, err := NewClient(context.TODO(), newTestingConnection(), testLoggerOption(), SimpleHubFactory(&singleHub{}))
 				Expect(err).To(HaveOccurred())
 				close(done)
 			})
@@ -206,7 +206,7 @@ var _ = Describe("Server options", func() {
 		})
 		Context("When no option which sets the hub type is used, NewServer", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewServer(context.TODO())
+				_, err := NewServer(context.TODO(), testLoggerOption())
 				Expect(err).NotTo(BeNil())
 				close(done)
 			})
@@ -223,7 +223,7 @@ var _ = Describe("Server options", func() {
 	Describe("EnableDetailedErrors option", func() {
 		Context("When the EnableDetailedErrors option false is used, calling a method which panics", func() {
 			It("should return a completion, which contains only the panic", func(done Done) {
-				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}))
+				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), testLoggerOption())
 				Expect(server).NotTo(BeNil())
 				Expect(err).To(BeNil())
 				conn := newTestingConnectionForServer()
@@ -244,7 +244,7 @@ var _ = Describe("Server options", func() {
 		})
 		Context("When the EnableDetailedErrors option true is used, calling a method which panics", func() {
 			It("should return a completion, which contains only the panic", func(done Done) {
-				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), EnableDetailedErrors(true))
+				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), EnableDetailedErrors(true), testLoggerOption())
 				Expect(server).NotTo(BeNil())
 				Expect(err).To(BeNil())
 				conn := newTestingConnectionForServer()
@@ -268,7 +268,7 @@ var _ = Describe("Server options", func() {
 	Describe("TimeoutInterval option", func() {
 		Context("When the TimeoutInterval has expired without any client message", func() {
 			It("the connection should be closed", func(done Done) {
-				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), TimeoutInterval(100*time.Millisecond))
+				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), TimeoutInterval(100*time.Millisecond), testLoggerOption())
 				Expect(server).NotTo(BeNil())
 				Expect(err).To(BeNil())
 				conn := newTestingConnectionForServer()
@@ -294,7 +294,7 @@ var _ = Describe("Server options", func() {
 	Describe("KeepAliveInterval option", func() {
 		Context("When the KeepAliveInterval has expired without any server message", func() {
 			It("a ping should have been sent", func(done Done) {
-				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), KeepAliveInterval(200*time.Millisecond))
+				server, err := NewServer(context.TODO(), UseHub(&invocationHub{}), KeepAliveInterval(200*time.Millisecond), testLoggerOption())
 				Expect(server).NotTo(BeNil())
 				Expect(err).To(BeNil())
 				conn := newTestingConnection()
@@ -327,7 +327,7 @@ var _ = Describe("Server options", func() {
 	Describe("StreamBufferCapacity option", func() {
 		Context("When the StreamBufferCapacity is 0", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), StreamBufferCapacity(0))
+				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), StreamBufferCapacity(0), testLoggerOption())
 				Expect(err).NotTo(BeNil())
 				close(done)
 			})
@@ -337,7 +337,7 @@ var _ = Describe("Server options", func() {
 	Describe("MaximumReceiveMessageSize option", func() {
 		Context("When the MaximumReceiveMessageSize is 0", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), MaximumReceiveMessageSize(0))
+				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), MaximumReceiveMessageSize(0), testLoggerOption())
 				Expect(err).NotTo(BeNil())
 				close(done)
 			})
@@ -346,19 +346,19 @@ var _ = Describe("Server options", func() {
 	Describe("HTTPTransports option", func() {
 		Context("When HTTPTransports is one of WebSockets, ServerSentEvents or both", func() {
 			It("should set these transports", func(done Done) {
-				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("WebSockets"))
+				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("WebSockets"), testLoggerOption())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(s.availableTransports()).To(ContainElement("WebSockets"))
 				close(done)
 			})
 			It("should set these transports", func(done Done) {
-				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("ServerSentEvents"))
+				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("ServerSentEvents"), testLoggerOption())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(s.availableTransports()).To(ContainElement("ServerSentEvents"))
 				close(done)
 			})
 			It("should set these transports", func(done Done) {
-				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("ServerSentEvents", "WebSockets"))
+				s, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("ServerSentEvents", "WebSockets"), testLoggerOption())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(s.availableTransports()).To(ContainElement("WebSockets"))
 				Expect(s.availableTransports()).To(ContainElement("ServerSentEvents"))
@@ -367,14 +367,14 @@ var _ = Describe("Server options", func() {
 		})
 		Context("When HTTPTransports is none of WebSockets, ServerSentEvents", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("WebTransport"))
+				_, err := NewServer(context.TODO(), UseHub(&singleHub{}), HTTPTransports("WebTransport"), testLoggerOption())
 				Expect(err).To(HaveOccurred())
 				close(done)
 			})
 		})
 		Context("When HTTPTransports is used on a client", func() {
 			It("should return an error", func(done Done) {
-				_, err := NewClient(context.TODO(), newTestingConnection(), HTTPTransports("ServerSentEvents"))
+				_, err := NewClient(context.TODO(), newTestingConnection(), HTTPTransports("ServerSentEvents"), testLoggerOption())
 				Expect(err).To(HaveOccurred())
 				close(done)
 			})

--- a/signalr_suite_test.go
+++ b/signalr_suite_test.go
@@ -2,11 +2,9 @@ package signalr
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -18,7 +16,7 @@ func TestSignalR(t *testing.T) {
 
 func connect(hubProto HubInterface) (Server, *testingConnection) {
 	server, err := NewServer(context.TODO(), SimpleHubFactory(hubProto),
-		Logger(log.NewLogfmtLogger(os.Stderr), true),
+		testLoggerOption(),
 		ChanReceiveTimeout(200*time.Millisecond),
 		StreamBufferCapacity(5))
 	if err != nil {

--- a/signalr_test/logger_test.go
+++ b/signalr_test/logger_test.go
@@ -1,0 +1,42 @@
+package signalr_test
+
+import (
+	"encoding/json"
+	"github.com/go-kit/kit/log"
+	"github.com/philippseith/signalr"
+	"io/ioutil"
+	"os"
+)
+
+type loggerConfig struct {
+	Enabled bool
+	Debug   bool
+}
+
+var lConf loggerConfig
+
+var tLog signalr.StructuredLogger
+
+func testLoggerOption() func(signalr.Party) error {
+	testLogger()
+	return signalr.Logger(tLog, lConf.Debug)
+}
+
+func testLogger() signalr.StructuredLogger {
+	if tLog == nil {
+		lConf = loggerConfig{Enabled: false, Debug: false}
+		b, err := ioutil.ReadFile("../testLogConf.json")
+		if err == nil {
+			err = json.Unmarshal(b, &lConf)
+			if err != nil {
+				lConf = loggerConfig{Enabled: false, Debug: false}
+			}
+		}
+		writer := ioutil.Discard
+		if lConf.Enabled {
+			writer = os.Stderr
+		}
+		tLog = log.NewLogfmtLogger(writer)
+	}
+	return tLog
+}

--- a/signalr_test/netconnection_test.go
+++ b/signalr_test/netconnection_test.go
@@ -29,7 +29,7 @@ var _ = Describe("NetConnection", func() {
 		It("should transport a simple invocation over raw rcp", func(done Done) {
 			var ctx context.Context
 			ctx, cancel := context.WithCancel(context.Background())
-			server, err := signalr.NewServer(ctx, signalr.SimpleHubFactory(&NetHub{}))
+			server, err := signalr.NewServer(ctx, signalr.SimpleHubFactory(&NetHub{}), testLoggerOption())
 			Expect(err).NotTo(HaveOccurred())
 			addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 			Expect(err).NotTo(HaveOccurred())
@@ -47,7 +47,7 @@ var _ = Describe("NetConnection", func() {
 			for {
 				if clientConn, err := net.Dial("tcp",
 					fmt.Sprintf("localhost:%v", listener.Addr().(*net.TCPAddr).Port)); err == nil {
-					client, err = signalr.NewClient(ctx, signalr.NewNetConnection(ctx, clientConn))
+					client, err = signalr.NewClient(ctx, signalr.NewNetConnection(ctx, clientConn), testLoggerOption())
 					Expect(err).NotTo(HaveOccurred())
 
 					break

--- a/signalr_test/server_test.go
+++ b/signalr_test/server_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/philippseith/signalr"
 )
 
@@ -101,7 +100,7 @@ func runServer(t *testing.T, serverIsUp chan struct{}, quitServer chan struct{},
 	sRServer, _ := signalr.NewServer(ctx, signalr.SimpleHubFactory(&hub{}),
 		signalr.KeepAliveInterval(2*time.Second),
 		transports,
-		signalr.Logger(log.NewLogfmtLogger(os.Stderr), true))
+		testLoggerOption())
 	router := http.NewServeMux()
 	sRServer.MapHTTP(router, "/hub")
 

--- a/streaminvocation_test.go
+++ b/streaminvocation_test.go
@@ -71,8 +71,7 @@ var _ = Describe("StreamInvocation", func() {
 		})
 		Context("When invoked by the client", func() {
 			It("should be invoked on the server, return stream items and a final completion without result", func(done Done) {
-				_, dbg := server.loggers()
-				p := &jsonHubProtocol{dbg: dbg}
+				p := &jsonHubProtocol{dbg: testLogger()}
 				conn.ClientSend(`{"type":4,"invocationId": "zzz","target":"simplestream"}`)
 				Expect(<-streamInvocationQueue).To(Equal("SimpleStream()"))
 				for i := 1; i < 4; i++ {
@@ -106,8 +105,7 @@ var _ = Describe("StreamInvocation", func() {
 		})
 		Context("When invoked by the client", func() {
 			It("should be invoked on the server, return stream items and a final completion without result", func(done Done) {
-				_, dbg := server.loggers()
-				protocol := jsonHubProtocol{dbg: dbg}
+				protocol := jsonHubProtocol{dbg: testLogger()}
 				conn.ClientSend(`{"type":4,"invocationId": "slice","target":"slicestream"}`)
 				Expect(<-streamInvocationQueue).To(Equal("SliceStream()"))
 				for i := 1; i < 4; i++ {
@@ -144,8 +142,7 @@ var _ = Describe("StreamInvocation", func() {
 		})
 		Context("When invoked by the client and stop after one result", func() {
 			It("should be invoked on the server, return stream one item and a final completion without result", func(done Done) {
-				_, dbg := server.loggers()
-				protocol := jsonHubProtocol{dbg: dbg}
+				protocol := jsonHubProtocol{dbg: testLogger()}
 				conn.ClientSend(`{"type":4,"invocationId": "xxx","target":"endlessstream"}`)
 				Expect(<-streamInvocationQueue).To(Equal("EndlessStream()"))
 				recv := (<-conn.received).(streamItemMessage)
@@ -188,8 +185,7 @@ var _ = Describe("StreamInvocation", func() {
 		})
 		Context("When invoked by the client and receiving an invalid CancelInvocation", func() {
 			It("should close the connection with an error", func(done Done) {
-				_, dbg := server.loggers()
-				protocol := &jsonHubProtocol{dbg: dbg}
+				protocol := &jsonHubProtocol{dbg: testLogger()}
 				conn.ClientSend(`{"type":4,"invocationId": "xyz","target":"endlessstream"}`)
 				Expect(<-streamInvocationQueue).To(Equal("EndlessStream()"))
 				recv := (<-conn.received).(streamItemMessage)
@@ -228,8 +224,7 @@ var _ = Describe("StreamInvocation", func() {
 		})
 		Context("When invoked by the client", func() {
 			It("should be invoked on the server, return one stream item with the \"no stream\" result and a final completion without result", func(done Done) {
-				_, dbg := server.loggers()
-				protocol := &jsonHubProtocol{dbg: dbg}
+				protocol := &jsonHubProtocol{dbg: testLogger()}
 				conn.ClientSend(`{"type":4,"invocationId": "yyy","target":"simpleint"}`)
 				Expect(<-streamInvocationQueue).To(Equal("SimpleInt()"))
 				sRecv := (<-conn.received).(streamItemMessage)

--- a/testLogConf.json
+++ b/testLogConf.json
@@ -1,0 +1,4 @@
+{
+  "Enabled": false,
+  "Debug": false
+}


### PR DESCRIPTION
To make the test results more readable, logging has been disabled by default. See README.md for configuration options.