### PR TITLE
fix typo in the "go get" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Protocol encoding in JSON is fully supported, and there is MessagePack support f
 With a [correctly configured](https://golang.org/doc/install#testing) Go toolchain:
 
 ```sh
-go get -u github.com/philippeseith/signalr
+go get -u github.com/philippseith/signalr
 ```
 
 ## Getting Started


### PR DESCRIPTION
it looks like there was a typo in the go get instructions.

somehow an extra `e` had snuck in which predictably gave me this error on install:
```
go get -u github.com/philippeseith/signalr
go get: module github.com/philippeseith/signalr: git ls-remote -q origin in /Users/davidalpert/go/pkg/mod/cache/vcs/4c5484719736c9adab3a5a0251c1f16d8cd7ecf587992e9b31d31497363ad1f9: exit status 128:
        remote: Repository not found.
        fatal: repository 'https://github.com/philippeseith/signalr/' not found
```

by using the correct repo name 'github.com/philippseith/signalr' the
package installs as expected.