### PR TITLE
httpmux.negotiate now returns 200 when successful

### DIFF
--- a/httpmux.go
+++ b/httpmux.go
@@ -188,6 +188,8 @@ func (h *httpMux) negotiate(w http.ResponseWriter, req *http.Request) {
 			NegotiateVersion:    negotiateVersion,
 			AvailableTransports: availableTransports,
 		}
+
+		w.WriteHeader(200)
 		_ = json.NewEncoder(w).Encode(response) // Can't imagine an error when encoding
 	}
 }


### PR DESCRIPTION
without writing the header, the response may not be properly
finished. I was getting errors trying to proxy this call through
a webpack dev server during development and suspect it's
because the negotiate handler didn't set a status code