### PR TITLE
avoid writing superflous response headers

### DIFF
--- a/httpmux.go
+++ b/httpmux.go
@@ -115,7 +115,9 @@ func (h *httpMux) handleServerSentEvent(writer http.ResponseWriter, request *htt
 func (h *httpMux) handleWebsocket(writer http.ResponseWriter, request *http.Request) {
 	websocketConn, err := websocket.Accept(writer, request, nil)
 	if err != nil {
-		writer.WriteHeader(400) // Bad request
+		_, debug := h.server.loggers()
+		debug.Log(evt, "handleWebsocket", msg, "error accepting websockets", "error", err)
+		// don't need to write an error header here as websocket.Accept has already used http.Error
 		return
 	}
 	connectionMapKey := request.URL.Query().Get("id")

--- a/httpmux.go
+++ b/httpmux.go
@@ -116,7 +116,7 @@ func (h *httpMux) handleWebsocket(writer http.ResponseWriter, request *http.Requ
 	websocketConn, err := websocket.Accept(writer, request, nil)
 	if err != nil {
 		_, debug := h.server.loggers()
-		debug.Log(evt, "handleWebsocket", msg, "error accepting websockets", "error", err)
+		_ = debug.Log(evt, "handleWebsocket", msg, "error accepting websockets", "error", err)
 		// don't need to write an error header here as websocket.Accept has already used http.Error
 		return
 	}


### PR DESCRIPTION
I have noticed that in the server-side logs I sometimes see this:

    2021/07/11 18:26:26 http: superfluous response.WriteHeader call from
      github.com/philippseith/signalr.(*httpMux).handleWebsocket (httpmux.go:118)

On investigation of the httpMux.handleWebsocket method it appears
that the websocket.Accept method writes an error header on every
path which returns an error object; thus when by the time this
method tests for an error returned from websocket.Accept, the
header has already been written.

this commit replaces that superflous writeheader call with a
log statement.