### PR TITLE
new: Hub.Context / HubContext.Context

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -1,6 +1,9 @@
 package signalr
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // HubInterface is a hubs interface
 type HubInterface interface {
@@ -40,6 +43,11 @@ func (h *Hub) Items() *sync.Map {
 // ConnectionID gets the ID of the current connection
 func (h *Hub) ConnectionID() string {
 	return h.context.ConnectionID()
+}
+
+// Context is the context.Context of the current connection
+func (h *Hub) Context() context.Context {
+	return h.context.Context()
 }
 
 // Abort aborts the current connection

--- a/hubcontext.go
+++ b/hubcontext.go
@@ -17,6 +17,7 @@ type HubContext interface {
 	Groups() GroupManager
 	Items() *sync.Map
 	ConnectionID() string
+	Context() context.Context
 	Abort()
 	Logger() (info StructuredLogger, dbg StructuredLogger)
 }
@@ -44,6 +45,10 @@ func (c *connectionHubContext) Items() *sync.Map {
 
 func (c *connectionHubContext) ConnectionID() string {
 	return c.connection.ConnectionID()
+}
+
+func (c *connectionHubContext) Context() context.Context {
+	return c.connection.Context()
 }
 
 func (c *connectionHubContext) Abort() {


### PR DESCRIPTION
By giving access to HubConnection.Context in Hub,
derived hubs can cancel goroutines when the connection has been closed.