### PR TITLE
fix: Remove needless check for EOF

### DIFF
--- a/hubcontext_test.go
+++ b/hubcontext_test.go
@@ -106,16 +106,9 @@ func connectMany() (Server, []*testingConnection, []string) {
 }
 
 var _ = Describe("HubContext", func() {
-	var server Server
-	var conns []*testingConnection
-	BeforeEach(func() {
-		server, conns, _ = connectMany()
-	})
-	AfterEach(func() {
-		server.cancel()
-	})
 	Context("Clients().All()", func() {
 		It("should invoke all clients", func(didIt Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(`{"type":1,"invocationId": "123","target":"callall"}`)
 			callCount := make(chan int, 1)
 			callCount <- 0
@@ -157,25 +150,17 @@ var _ = Describe("HubContext", func() {
 			case <-time.After(3000 * time.Millisecond):
 				Fail("timed out")
 			}
+			server.cancel()
 			close(didIt)
 		}, 5.0)
 	})
 })
 
 var _ = Describe("HubContext", func() {
-	var server Server
-	var conns []*testingConnection
-	BeforeEach(func(done Done) {
-		server, conns, _ = connectMany()
-		close(done)
-	})
-	AfterEach(func(done Done) {
-		server.cancel()
-		close(done)
-	})
 
 	Context("Clients().Caller()", func() {
 		It("should invoke only the caller", func(didIt Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(`{"type":1,"invocationId": "123","target":"callcaller"}`)
 			done := make(chan bool)
 			callCount := make(chan int, 1)
@@ -209,12 +194,14 @@ var _ = Describe("HubContext", func() {
 			case <-time.After(3000 * time.Millisecond):
 				Fail("timed out")
 			}
+			server.cancel()
 			close(didIt)
 		}, 4.0)
 	})
 
 	Context("Clients().Client()", func() {
 		It("should invoke only the client which was addressed", func(didIt Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(fmt.Sprintf(`{"type":1,"invocationId": "123","target":"callclient","arguments":["%v"]}`, conns[2].ConnectionID()))
 			done := make(chan bool)
 			go func(conns []*testingConnection) {
@@ -250,12 +237,14 @@ var _ = Describe("HubContext", func() {
 			case <-time.After(3000 * time.Millisecond):
 				Fail("timed out")
 			}
+			server.cancel()
 			close(didIt)
 		}, 4.0)
 	})
 
 	Context("Clients().Group()", func() {
 		It("should invoke only the clients in the group", func(ditIt Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(fmt.Sprintf(`{"type":1,"invocationId": "123","target":"buildgroup","arguments":["%v","%v"]}`, conns[1].ConnectionID(), conns[2].ConnectionID()))
 			<-hubContextInvocationQueue
 			<-conns[0].received
@@ -294,12 +283,14 @@ var _ = Describe("HubContext", func() {
 			case <-time.After(3000 * time.Millisecond):
 				Fail("timed out")
 			}
+			server.cancel()
 			close(ditIt)
 		}, 4.0)
 	})
 
 	Context("RemoveFromGroup should remove clients from the group", func() {
 		It("should invoke only the clients in the group", func(ditIt Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(fmt.Sprintf(`{"type":1,"invocationId": "123","target":"buildgroup","arguments":["%v","%v"]}`, conns[1].ConnectionID(), conns[2].ConnectionID()))
 			Expect(<-hubContextInvocationQueue).To(Equal("BuildGroup()"))
 			<-conns[0].received
@@ -339,12 +330,14 @@ var _ = Describe("HubContext", func() {
 			}(conns, done)
 			Expect(<-hubContextInvocationQueue).To(Equal("CallGroup()"))
 			<-done
+			server.cancel()
 			close(ditIt)
 		}, 4.0)
 	})
 
 	Context("Items()", func() {
 		It("should hold Items connection wise", func(done Done) {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(`{"type":1,"invocationId": "123","target":"additem","arguments":["first",1]}`)
 			// Wait for execution
 			Expect(<-hubContextInvocationQueue).To(Equal("AddItem()"))
@@ -363,27 +356,20 @@ var _ = Describe("HubContext", func() {
 			msg = <-conns[1].received
 			Expect(msg).To(BeAssignableToTypeOf(completionMessage{}))
 			Expect(msg.(completionMessage).Result).To(BeNil())
+			server.cancel()
 			close(done)
 		}, 2.0)
 	})
 })
 
 var _ = Describe("HubContext", func() {
-	var server Server
-	var conns []*testingConnection
-	BeforeEach(func(done Done) {
-		server, conns, _ = connectMany()
-		close(done)
-	})
-	AfterEach(func(done Done) {
-		server.cancel()
-		close(done)
-	})
 	Context("ConnectionID", func() {
 		It("should be the ID of the connection", func() {
+			server, conns, _ := connectMany()
 			conns[0].ClientSend(`{"type":1,"invocationId": "ABC","target":"testconnectionid"}`)
 			id := <-hubContextInvocationQueue
 			Expect(strings.Index(id, "test")).To(Equal(0))
+			server.cancel()
 		})
 	})
 })

--- a/jsonhubprotocol.go
+++ b/jsonhubprotocol.go
@@ -160,8 +160,7 @@ func readJSONFrames(reader io.Reader, remainBuf *bytes.Buffer) ([][]byte, error)
 	// Try getting data until at least one frame is available
 	for {
 		n, err := reader.Read(p)
-		// Some reader implementations return io.EOF additionally to n=0 if no data could be read
-		if err != nil && !errors.Is(err, io.EOF) {
+		if err != nil {
 			return nil, err
 		}
 		if n > 0 {


### PR DESCRIPTION
All connection errors occurred while parsing a json frame should lead to an end of parsing. None of currently used io.Reader implementations is sending an io.EOF error if there is currently no data, but only when the Reader/connection has been closed.