### PR TITLE
Remove log timestamps introduced in #106

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,12 +98,6 @@ func NewClient(ctx context.Context, options ...func(Party) error) (Client, error
 			}
 		}
 	}
-	// Wrap logging with timestamps
-	info, dbg = c.loggers()
-	c.setLoggers(
-		log.WithPrefix(info, "ts", log.DefaultTimestampUTC),
-		log.WithPrefix(dbg, "ts", log.DefaultTimestampUTC),
-	)
 	if c.conn == nil && c.connectionFactory == nil {
 		return nil, errors.New("neither WithConnection nor WithAutoReconnect option was given")
 	}


### PR DESCRIPTION
@philippseith 

> IMHO the timestamp should be taken when the event occurs. This is vital if you have a distributed system.
go-kit/log is a structured logger, so it should be simple to strip the ts key/value pair if you like to add a timestamp yourself.

Fair enough. The argument of adding anything (timestamp etc) to the log message can be done by the logger though and that is configurable and invoked at the time the message occurs, so can be handled outside the lib. I wouldn't expect a logger to remove stuff in order to match its own logging systematics.

In other words: the current change forces other loggers to remove data that is implementation details instead of public api.

But before it gets philosophical- happy to have this closed if you want to keep as-is, removing it is possible (while relying on internal details).