### PR TITLE
[feature/display_remoteaddr] adding remoteaddr information

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,11 @@ type pipeConnection struct {
 	timeout      time.Duration
 	fail         atomic.Value
 	connectionID string
+	remoteAddr   string
+}
+
+func (pc *pipeConnection) RemoteAddr() string {
+	return pc.remoteAddr
 }
 
 func (pc *pipeConnection) Context() context.Context {
@@ -62,11 +67,13 @@ func newClientServerConnections() (cliConn *pipeConnection, svrConn *pipeConnect
 		reader:       cliReader,
 		writer:       cliWriter,
 		connectionID: "X",
+		remoteAddr:   "127.0.0.1",
 	}
 	svrConn = &pipeConnection{
 		reader:       srvReader,
 		writer:       srvWriter,
 		connectionID: "X",
+		remoteAddr:   "127.0.0.1",
 	}
 	return cliConn, svrConn
 }

--- a/clientsseconnection.go
+++ b/clientsseconnection.go
@@ -17,7 +17,7 @@ type clientSSEConnection struct {
 	sseWriter io.Writer
 }
 
-func newClientSSEConnection(address string, connectionID string, body io.ReadCloser) (*clientSSEConnection, error) {
+func newClientSSEConnection(address string, connectionID string, remoteAddr string, body io.ReadCloser) (*clientSSEConnection, error) {
 	// Setup request
 	reqURL, err := url.Parse(address)
 	if err != nil {
@@ -30,6 +30,7 @@ func newClientSSEConnection(address string, connectionID string, body io.ReadClo
 		ConnectionBase: ConnectionBase{
 			ctx:          context.Background(),
 			connectionID: connectionID,
+			remoteAddr:   remoteAddr,
 		},
 		reqURL: reqURL.String(),
 	}

--- a/connection.go
+++ b/connection.go
@@ -12,6 +12,7 @@ type Connection interface {
 	Context() context.Context
 	ConnectionID() string
 	SetConnectionID(id string)
+	RemoteAddr() string
 }
 
 // TransferMode is either TextTransferMode or BinaryTransferMode

--- a/connectionbase.go
+++ b/connectionbase.go
@@ -10,13 +10,15 @@ type ConnectionBase struct {
 	mx           sync.RWMutex
 	ctx          context.Context
 	connectionID string
+	remoteAddr   string
 }
 
 // NewConnectionBase creates a new ConnectionBase
-func NewConnectionBase(ctx context.Context, connectionID string) *ConnectionBase {
+func NewConnectionBase(ctx context.Context, connectionID string, remoteAddr string) *ConnectionBase {
 	cb := &ConnectionBase{
 		ctx:          ctx,
 		connectionID: connectionID,
+		remoteAddr:   remoteAddr,
 	}
 	return cb
 }
@@ -33,6 +35,13 @@ func (cb *ConnectionBase) ConnectionID() string {
 	cb.mx.RLock()
 	defer cb.mx.RUnlock()
 	return cb.connectionID
+}
+
+// RemoteAddr is the ip of the remote host.
+func (cb *ConnectionBase) RemoteAddr() string {
+	cb.mx.RLock()
+	defer cb.mx.RUnlock()
+	return cb.remoteAddr
 }
 
 // SetConnectionID sets the ConnectionID

--- a/httpconnection.go
+++ b/httpconnection.go
@@ -119,7 +119,7 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 			return nil, err
 		}
 
-		conn = newWebSocketConnection(context.Background(), nr.ConnectionID, ws)
+		conn = newWebSocketConnection(context.Background(), nr.ConnectionID, address, ws)
 
 	case nr.getTransferFormats("ServerSentEvents") != nil:
 		req, err := http.NewRequest("GET", reqURL.String(), nil)
@@ -137,7 +137,7 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 			return nil, err
 		}
 
-		conn, err = newClientSSEConnection(address, nr.ConnectionID, resp.Body)
+		conn, err = newClientSSEConnection(address, nr.ConnectionID, req.RemoteAddr, resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/httpmux.go
+++ b/httpmux.go
@@ -102,7 +102,7 @@ func (h *httpMux) handleServerSentEvent(writer http.ResponseWriter, request *htt
 	if ok {
 		if _, ok := c.(*negotiateConnection); ok {
 			ctx, _ := onecontext.Merge(h.server.context(), request.Context())
-			sseConn, jobChan, jobResultChan, err := newServerSSEConnection(ctx, c.ConnectionID())
+			sseConn, jobChan, jobResultChan, err := newServerSSEConnection(ctx, c.ConnectionID(), request.RemoteAddr)
 			if err != nil {
 				writer.WriteHeader(http.StatusInternalServerError)
 				return
@@ -173,7 +173,7 @@ func (h *httpMux) handleWebsocket(writer http.ResponseWriter, request *http.Requ
 		if _, ok := c.(*negotiateConnection); ok {
 			// Connection is negotiated but not initiated
 			ctx, _ := onecontext.Merge(h.server.context(), request.Context())
-			err = h.serveConnection(newWebSocketConnection(ctx, c.ConnectionID(), websocketConn))
+			err = h.serveConnection(newWebSocketConnection(ctx, c.ConnectionID(), request.RemoteAddr, websocketConn))
 			if err != nil {
 				_ = websocketConn.Close(1005, err.Error())
 			}

--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -212,7 +212,7 @@ func handShakeAndCallWebSocketTestServer(port int, connectionID string) {
 	defer func() {
 		_ = ws.Close(websocket.StatusNormalClosure, "")
 	}()
-	wsConn := newWebSocketConnection(context.TODO(), connectionID, ws)
+	wsConn := newWebSocketConnection(context.TODO(), connectionID, "127.0.0.1", ws)
 	cliConn := newHubConnection(wsConn, &protocol, 1<<15, testLogger())
 	_, _ = wsConn.Write(append([]byte(`{"protocol": "json","version": 1}`), 30))
 	_, _ = wsConn.Write(append([]byte(`{"type":1,"invocationId":"666","target":"add2","arguments":[1]}`), 30))

--- a/hub.go
+++ b/hub.go
@@ -53,6 +53,13 @@ func (h *Hub) ConnectionID() string {
 	return h.context.ConnectionID()
 }
 
+// ConnectionID gets the ID of the current connection
+func (h *Hub) RemoteAddr() string {
+	h.cm.RLock()
+	defer h.cm.RUnlock()
+	return h.context.RemoteAddr()
+}
+
 // Context is the context.Context of the current connection
 func (h *Hub) Context() context.Context {
 	h.cm.RLock()

--- a/hubconnection.go
+++ b/hubconnection.go
@@ -13,6 +13,7 @@ import (
 // hubConnection uses a transport connection (of type Connection) and a hubProtocol to send and receive SignalR messages.
 type hubConnection interface {
 	ConnectionID() string
+	RemoteAddr() string
 	Receive() <-chan receiveResult
 	SendInvocation(id string, target string, args []interface{}) error
 	SendStreamInvocation(id string, target string, args []interface{}, streamIds []string) error
@@ -76,6 +77,10 @@ func (c *defaultHubConnection) Close(errorText string, allowReconnect bool) erro
 
 func (c *defaultHubConnection) ConnectionID() string {
 	return c.connection.ConnectionID()
+}
+
+func (c *defaultHubConnection) RemoteAddr() string {
+	return c.connection.RemoteAddr()
 }
 
 func (c *defaultHubConnection) Context() context.Context {

--- a/hubcontext.go
+++ b/hubcontext.go
@@ -17,6 +17,7 @@ type HubContext interface {
 	Groups() GroupManager
 	Items() *sync.Map
 	ConnectionID() string
+	RemoteAddr() string
 	Context() context.Context
 	Abort()
 	Logger() (info StructuredLogger, dbg StructuredLogger)
@@ -45,6 +46,10 @@ func (c *connectionHubContext) Items() *sync.Map {
 
 func (c *connectionHubContext) ConnectionID() string {
 	return c.connection.ConnectionID()
+}
+
+func (c *connectionHubContext) RemoteAddr() string {
+	return c.connection.RemoteAddr()
 }
 
 func (c *connectionHubContext) Context() context.Context {

--- a/netconnection.go
+++ b/netconnection.go
@@ -17,7 +17,7 @@ type netConnection struct {
 // NewNetConnection wraps net.Conn into a Connection
 func NewNetConnection(ctx context.Context, conn net.Conn) Connection {
 	netConn := &netConnection{
-		ConnectionBase: *NewConnectionBase(ctx, getConnectionID()),
+		ConnectionBase: *NewConnectionBase(ctx, getConnectionID(), conn.RemoteAddr().String()),
 		conn:           conn,
 	}
 	go func() {

--- a/serversseconnection.go
+++ b/serversseconnection.go
@@ -21,9 +21,9 @@ type serverSSEConnection struct {
 	jobResultChan chan RWJobResult
 }
 
-func newServerSSEConnection(ctx context.Context, connectionID string) (*serverSSEConnection, <-chan []byte, chan RWJobResult, error) {
+func newServerSSEConnection(ctx context.Context, connectionID string, remoteAddr string) (*serverSSEConnection, <-chan []byte, chan RWJobResult, error) {
 	s := serverSSEConnection{
-		ConnectionBase: *NewConnectionBase(ctx, connectionID),
+		ConnectionBase: *NewConnectionBase(ctx, connectionID, remoteAddr),
 		jobChan:        make(chan []byte, 1),
 		jobResultChan:  make(chan RWJobResult, 1),
 	}

--- a/testingconnection_test.go
+++ b/testingconnection_test.go
@@ -16,6 +16,7 @@ import (
 type testingConnection struct {
 	timeout      time.Duration
 	connectionID string
+	remoteAddr   string
 	srvWriter    io.Writer
 	srvReader    io.Reader
 	cliWriter    io.Writer
@@ -28,6 +29,10 @@ type testingConnection struct {
 	failRead     string
 	failWrite    string
 	failMx       sync.Mutex
+}
+
+func (t *testingConnection) RemoteAddr() string {
+	return t.remoteAddr
 }
 
 func (t *testingConnection) Context() context.Context {

--- a/websocketconnection.go
+++ b/websocketconnection.go
@@ -14,10 +14,10 @@ type webSocketConnection struct {
 	transferMode TransferMode
 }
 
-func newWebSocketConnection(ctx context.Context, connectionID string, conn *websocket.Conn) *webSocketConnection {
+func newWebSocketConnection(ctx context.Context, connectionID string, remoteAddr string, conn *websocket.Conn) *webSocketConnection {
 	w := &webSocketConnection{
 		conn:           conn,
-		ConnectionBase: *NewConnectionBase(ctx, connectionID),
+		ConnectionBase: *NewConnectionBase(ctx, connectionID, remoteAddr),
 	}
 	return w
 }


### PR DESCRIPTION
I had a use case where I needed to get remoteaddr (IP) of the clients so I added it to the hub as a getter like the connectionid