### PR TITLE
fix client https server with query

### DIFF
--- a/httpconnection.go
+++ b/httpconnection.go
@@ -61,10 +61,7 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 		return nil, err
 	}
 
-	negotiateURL := func(u *url.URL) *url.URL {
-		tmp := *u
-		return &tmp
-	}(reqURL)
+	negotiateURL := *reqURL
 	negotiateURL.Path = path.Join(negotiateURL.Path, "negotiate")
 	req, err := http.NewRequestWithContext(ctx, "POST", negotiateURL.String(), nil)
 	if err != nil {


### PR DESCRIPTION
1. When use `NewHTTPConnection` function connecting to the service, the url contains query, then negotiate path will be error
eg:
`https://localhost:8088/hub/chat?uid=a`  to negotiate path is `https://localhost:8088/hub/chat?uid=a/negotiate`

2. When connecting to https service, I pass in custom `httpConn.client` with transport, but in case of WebSockets, `websocket.DialOptions` does not set custom `httpConn.client`
eg：
```
conn, err := signalr.NewHTTPConnection(
		ctx,
		url,
		signalr.WithHTTPClient(&http.Client{
			Transport: &http.Transport{
				TLSClientConfig: &tls.Config{
					InsecureSkipVerify: true,
				},
			},
		}),
```