### PR TITLE
Call SetReadLimit on websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/philippseith/signalr
+module github.com/mvdslot/signalr
 
 go 1.16
 

--- a/httpmux.go
+++ b/httpmux.go
@@ -156,6 +156,7 @@ func (h *httpMux) handleWebsocket(writer http.ResponseWriter, request *http.Requ
 		// don't need to write an error header here as websocket.Accept has already used http.Error
 		return
 	}
+	websocketConn.SetReadLimit(int64(h.server.maximumReceiveMessageSize()))
 	connectionMapKey := request.URL.Query().Get("id")
 	if connectionMapKey == "" {
 		// Support websocket connection without negotiate

--- a/router/go.mod
+++ b/router/go.mod
@@ -1,4 +1,4 @@
-module github.com/philippseith/signalr/router
+module github.com/mvdslot/signalr/router
 
 go 1.17
 


### PR DESCRIPTION
This solved the MessageTooBig when receiving messages that are greater than 32K.