### PR TITLE
Don't use HTTP client for Websocket connection

### DIFF
--- a/httpconnection.go
+++ b/httpconnection.go
@@ -114,11 +114,6 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 
 		opts := &websocket.DialOptions{}
 
-		client, ok := httpConn.client.(*http.Client)
-		if ok {
-			opts.HTTPClient = client
-		}
-
 		if httpConn.headers != nil {
 			opts.HTTPHeader = httpConn.headers()
 		}


### PR DESCRIPTION
Fix https://github.com/philippseith/signalr/issues/136

The optional HTTP client promises a `Doer` interface. It is- in our case- not suitable as an `http.Client` due to the underlying client's transport intercepting the HTTP traffic for logging purposes.

My suggestion here it to revert this specific part of https://github.com/philippseith/signalr/commit/2c9444d948b3aab875ac0a713ebae7d70455e55e and- if setting websocket client is required- add an additional `WithWebsocketClient` option with `*http.Client` signature instead of `Doer`.

/cc @BenLocal 