### PR TITLE
MaximumReceiveMessageSize comment mention to bytes

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,14 +57,14 @@ func StreamBufferCapacity(capacity uint) func(Party) error {
 	}
 }
 
-// MaximumReceiveMessageSize is the maximum size of a single incoming hub message.
+// MaximumReceiveMessageSize is the maximum size in bytes of a single incoming hub message.
 // Default is 32768 bytes (32KB)
-func MaximumReceiveMessageSize(sizeOnBytes uint) func(Party) error {
+func MaximumReceiveMessageSize(sizeInBytes uint) func(Party) error {
 	return func(p Party) error {
-		if sizeOnBytes == 0 {
+		if sizeInBytes == 0 {
 			return errors.New("unsupported maximumReceiveMessageSize 0")
 		}
-		p.setMaximumReceiveMessageSize(sizeOnBytes)
+		p.setMaximumReceiveMessageSize(sizeInBytes)
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -58,13 +58,13 @@ func StreamBufferCapacity(capacity uint) func(Party) error {
 }
 
 // MaximumReceiveMessageSize is the maximum size of a single incoming hub message.
-// Default is 32KB
-func MaximumReceiveMessageSize(size uint) func(Party) error {
+// Default is 32768 bytes (32KB)
+func MaximumReceiveMessageSize(sizeOnBytes uint) func(Party) error {
 	return func(p Party) error {
-		if size == 0 {
+		if sizeOnBytes == 0 {
 			return errors.New("unsupported maximumReceiveMessageSize 0")
 		}
-		p.setMaximumReceiveMessageSize(size)
+		p.setMaximumReceiveMessageSize(sizeOnBytes)
 		return nil
 	}
 }


### PR DESCRIPTION
does this `MaximumReceiveMessageSize` use bytes as units?

I assumed it based on this line

    const defaultReadLimit = 32768

https://github.com/nhooyr/websocket/blob/master/read.go#L78

I added a mention of bytes in the comment of the function, and I changed the name of the var to identify the unit used easily.

If these changes are not useful, please reject the pull request.

thanks.