### PR TITLE
pass cookies returned from negotiation endpoint to ws

### DIFF
--- a/httpconnection.go
+++ b/httpconnection.go
@@ -117,6 +117,12 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 
 		if httpConn.headers != nil {
 			opts.HTTPHeader = httpConn.headers()
+		} else {
+			opts.HTTPHeader = http.Header{}
+		}
+
+		for _, cookie := range resp.Cookies() {
+			opts.HTTPHeader.Add("Cookie", cookie.String())
 		}
 
 		ws, _, err := websocket.Dial(ctx, wsURL.String(), opts)


### PR DESCRIPTION
Related to: https://github.com/philippseith/signalr/issues/142

As far as I've tested this now successfully passes the cookie along when making ws connection and I was able to establish a connection successfully.

Thank you again @philippseith for helping me in the linked issue. If there's anything else you'd like me to change in this PR do tell.