### PR TITLE
fix: Missing SetReadLimit for websocket connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -136,6 +136,10 @@ func NewClient(ctx context.Context, options ...func(Party) error) (Client, error
 	if c.conn == nil && c.connectionFactory == nil {
 		return nil, ErrUnableToConnect
 	}
+	// Pass maximum receive message size to the websocket
+	if wsConn, ok := c.conn.(*webSocketConnection); ok {
+		wsConn.conn.SetReadLimit(int64(c.maximumReceiveMessageSize()))
+	}
 	return c, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -136,10 +136,6 @@ func NewClient(ctx context.Context, options ...func(Party) error) (Client, error
 	if c.conn == nil && c.connectionFactory == nil {
 		return nil, ErrUnableToConnect
 	}
-	// Pass maximum receive message size to the websocket
-	if wsConn, ok := c.conn.(*webSocketConnection); ok {
-		wsConn.conn.SetReadLimit(int64(c.maximumReceiveMessageSize()))
-	}
 	return c, nil
 }
 
@@ -269,6 +265,10 @@ func (c *client) setupConnectionAndProtocol() (hubProtocol, error) {
 			if err != nil {
 				return nil, err
 			}
+		}
+		// Pass maximum receive message size to a potential websocket connection
+		if wsConn, ok := c.conn.(*webSocketConnection); ok {
+			wsConn.conn.SetReadLimit(int64(c.maximumReceiveMessageSize()))
 		}
 		protocol, err := c.processHandshake()
 		if err != nil {

--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -99,6 +99,7 @@ var _ = Describe("HTTP server", func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					server, err := NewServer(ctx,
 						SimpleHubFactory(&addHub{}), HTTPTransports(transport[0]),
+						MaximumReceiveMessageSize(50000),
 						Logger(logger, true))
 					Expect(err).NotTo(HaveOccurred())
 					router := http.NewServeMux()
@@ -112,6 +113,7 @@ var _ = Describe("HTTP server", func() {
 					Expect(err).NotTo(HaveOccurred())
 					client, err := NewClient(ctx,
 						WithConnection(conn),
+						MaximumReceiveMessageSize(60000),
 						Logger(logger, true),
 						TransferFormat(transport[1]))
 					Expect(err).NotTo(HaveOccurred())
@@ -190,7 +192,7 @@ func negotiateWebSocketTestServer(port int) map[string]interface{} {
 		_ = resp.Body.Close()
 	}()
 	var body []byte
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	Expect(err).To(BeNil())
 	response := make(map[string]interface{})
 	err = json.Unmarshal(body, &response)


### PR DESCRIPTION
SetReadLimit was only set on the server side