### PR TITLE
Fix client example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ if err != nil {
     return err
 }
 // Create the client and set a receiver for callbacks from the server
-client, err := signalr.NewClient(ctx, conn,
+client, err := signalr.NewClient(ctx,
 	signalr.WithConnection(conn),
 	signalr.WithReceiver(receiver))
 if err != nil {


### PR DESCRIPTION
It seems that the old version of NewClient included the connection as the second argument, but it is now passed via WithConnection option.