### PR TITLE
Support multiple negotiate versions and handle backoff.Stop properly

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,6 +204,7 @@ func (c *client) Start() {
 			nextBackoff := boff.NextBackOff()
 			// Check for exceeded backoff
 			if nextBackoff == backoff.Stop {
+				c.setState(ClientClosed)
 				c.setErr(errors.New("backoff exceeded"))
 				return
 			}

--- a/httpconnection.go
+++ b/httpconnection.go
@@ -113,7 +113,13 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 	}
 
 	q := reqURL.Query()
-	q.Set("id", negotiateResponse.ConnectionID)
+	switch negotiateResponse.NegotiateVersion {
+	case 0:
+		q.Set("id", negotiateResponse.ConnectionID)
+	case 1:
+		q.Set("id", negotiateResponse.ConnectionToken)
+	}
+
 	reqURL.RawQuery = q.Encode()
 
 	// Select the best connection


### PR DESCRIPTION
According to the [SignalR specification](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md#version-1), based on negotiateVersion, the client should set connection id (v0) or connection token (v1) to the "id" query parameter.

Also, noticed that `backoff.Stop` doesn't change the client's status to Closed