### PR TITLE
Use negotiateVersion from query parameter if present

### DIFF
--- a/httpmux.go
+++ b/httpmux.go
@@ -194,10 +194,25 @@ func (h *httpMux) negotiate(w http.ResponseWriter, req *http.Request) {
 	} else {
 		connectionID := newConnectionID()
 		connectionMapKey := connectionID
-		negotiateVersion, err := strconv.Atoi(req.Header.Get("negotiateVersion"))
+
+		// Check the header for negotiateVersion
+		headerNegotiateVersion, err := strconv.Atoi(req.Header.Get("negotiateVersion"))
 		if err != nil {
-			negotiateVersion = 0
+			headerNegotiateVersion = 0
 		}
+
+		// Check the query parameter for negotiateVersion
+		queryNegotiateVersion, err := strconv.Atoi(req.URL.Query().Get("negotiateVersion"))
+		if err != nil {
+			queryNegotiateVersion = 0
+		}
+
+		// Use the negotiateVersion from query if present, otherwise use the one from the header parameter
+		negotiateVersion := queryNegotiateVersion
+		if headerNegotiateVersion != 0 {
+			negotiateVersion = headerNegotiateVersion
+		}
+
 		connectionToken := ""
 		if negotiateVersion == 1 {
 			connectionToken = newConnectionID()


### PR DESCRIPTION
In reference to issue #186 

> In the POST request the client sends a query string parameter with the key "negotiateVersion" and the value as the negotiate protocol version it would like to use.

Adding support to read from query parameter as well as header for negotiate version. Will use whichever one isn't version 0 if any.