### PR TITLE
feat: support `ReceiveFunc` for client. #73

### DIFF
--- a/loop.go
+++ b/loop.go
@@ -369,13 +369,20 @@ func buildMethodArguments(method reflect.Value, invocation invocationMessage,
 }
 
 func getMethod(target interface{}, name string) (reflect.Value, bool) {
+	if receiver, ok := target.(ReceiverInterface); ok {
+		if method := receiver.GetFunc(name); method != nil {
+			return reflect.ValueOf(method), true
+		}
+	}
+
 	hubType := reflect.TypeOf(target)
 	if hubType != nil {
 		hubValue := reflect.ValueOf(target)
-		name = strings.ToLower(name)
+		lowCaseName := strings.ToLower(name)
+
 		for i := 0; i < hubType.NumMethod(); i++ {
 			// Search in public methods
-			if m := hubType.Method(i); strings.ToLower(m.Name) == name {
+			if m := hubType.Method(i); strings.ToLower(m.Name) == lowCaseName {
 				return hubValue.Method(i), true
 			}
 		}

--- a/receiver.go
+++ b/receiver.go
@@ -1,20 +1,35 @@
 package signalr
 
 // ReceiverInterface allows receivers to interact with the server directly from the receiver methods
-//  Init(Client)
+//
+//	Init(Client)
+//
 // Init is used by the Client to connect the receiver to the server.
-//  Server() Client
+//
+//	Server() Client
+//
 // Server can be used inside receiver methods to call Client methods,
 // e.g. Client.Send, Client.Invoke, Client.PullStream and Client.PushStreams
+//
+//	GetFunc(string) interface{}
+//
+// GetFunc is used to get the handler function by handler name.
+//
+//	SetFunc(string, interface{})
+//
+// SetFunc is used to set the mapping between the name and the handler function.
 type ReceiverInterface interface {
 	Init(Client)
 	Server() Client
+	GetFunc(string) interface{}
+	SetFunc(string, interface{})
 }
 
 // Receiver is a base class for receivers in the client.
 // It implements ReceiverInterface
 type Receiver struct {
-	client Client
+	methodMap map[string]interface{}
+	client    Client
 }
 
 // Init is used by the Client to connect the receiver to the server.
@@ -25,4 +40,26 @@ func (ch *Receiver) Init(client Client) {
 // Server can be used inside receiver methods to call Client methods,
 func (ch *Receiver) Server() Client {
 	return ch.client
+}
+
+// GetFunc is used to get the handler function by handler name.
+func (ch *Receiver) GetFunc(name string) interface{} {
+	return ch.methodMap[name]
+}
+
+// SetFunc is used to set the mapping between the name and the handler function.
+func (ch *Receiver) SetFunc(name string, fn interface{}) {
+	if ch.methodMap == nil {
+		ch.methodMap = make(map[string]interface{})
+	}
+	if _, ok := ch.methodMap[name]; ok {
+		info, _ := ch.client.loggers()
+		_ = info.Log(evt, "set function", "warn", "method has been overridden", "method", name)
+	}
+	ch.methodMap[name] = fn
+}
+
+// On is an alias for SetFunc
+func (ch *Receiver) On(name string, fn interface{}) {
+	ch.SetFunc(name, fn)
 }


### PR DESCRIPTION
Add `ReceiveFunc` for client, use method map in base receiver, to support the methods that cannot be named in Go. 