### PR TITLE
Feature: Add Close Method to Hub for Custom Error Signaling and Connection Closure

### DIFF
--- a/chatsample/main.go
+++ b/chatsample/main.go
@@ -40,6 +40,11 @@ func (c *chat) Echo(message string) {
 	c.Clients().Caller().Send("receive", message)
 }
 
+func (c *chat) DoSomethingBugy() {
+	c.Close("this is a custom error!", true)
+}
+
+
 func (c *chat) Panic() {
 	panic("Don't panic!")
 }

--- a/chatsample/public/index.html
+++ b/chatsample/public/index.html
@@ -11,6 +11,7 @@
     <input type="button" value="Stop Stream" id="stopstream" />
     <input type="button" value="Upstream" id="upstream" />
     <input type="button" value="Stop/Start Client Connection" id="stop" />
+    <input type="button" value="close Client Connection with error" id="close" />
     <input type="button" value="Abort Server Connection" id="abort" />
     <ul id="messages">
     </ul>
@@ -114,6 +115,11 @@
             document.getElementById('abort').addEventListener('click', () => {
                 connection.send('abort')
             });
+
+            document.getElementById('close').addEventListener('click', () => {
+                connection.send('DoSomethingBugy')
+            });
+
             connection.on('receive', message => {
                 var li = document.createElement('li');
                 li.innerText = 'sent ' + message;

--- a/hub.go
+++ b/hub.go
@@ -79,3 +79,9 @@ func (h *Hub) OnConnected(string) {}
 
 // OnDisconnected is called when the hub is disconnected
 func (h *Hub) OnDisconnected(string) {}
+
+func (h *Hub) Close(errorMessage string, allowReconnect bool) {
+	h.cm.RLock()
+	defer h.cm.RUnlock()
+	h.context.Close(errorMessage, allowReconnect)
+}

--- a/hubcontext.go
+++ b/hubcontext.go
@@ -20,6 +20,7 @@ type HubContext interface {
 	Context() context.Context
 	Abort()
 	Logger() (info StructuredLogger, dbg StructuredLogger)
+	Close(errorMessage string, allowReconnect bool)
 }
 
 type connectionHubContext struct {
@@ -57,4 +58,8 @@ func (c *connectionHubContext) Abort() {
 
 func (c *connectionHubContext) Logger() (info StructuredLogger, dbg StructuredLogger) {
 	return c.info, c.dbg
+}
+
+func (c *connectionHubContext) Close(errorMessage string, allowReconnect bool) {
+	c.connection.Close(errorMessage, allowReconnect)
 }


### PR DESCRIPTION
# Add `Close` Method to Hub for Custom Error Signaling and Connection Closure

## Summary

This pull request introduces a new `Close` method to the `Hub` and `HubContext` in the SignalR Go implementation. The new method allows server-side code to **send a custom error message to the client using the SignalR protocol's close message** and then cleanly close the connection, optionally allowing the client to reconnect.

---

## Why is this needed?

Previously, there was no reliable, protocol-compliant way to send a custom error to the client and then close the connection. The only options were:

- Calling `Abort()`, which closes the connection immediately and sends a generic cancellation error.
- Attempting to send a message and then aborting, which is unreliable because the message may not reach the client before the connection is closed.

**The SignalR protocol defines a "close" message (type 7) that can include an error field.** This is the intended way to inform clients of errors that cause the connection to close, and is supported by all official SignalR clients ([see protocol spec](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/HubProtocol.md)).

---

## What does this PR change?

- **Adds a `Close(errorMessage string, allowReconnect bool)` method to `Hub` and `HubContext`.**
- The method sends a SignalR close message with the provided error and reconnection policy, then closes the connection.
- This is a protocol-compliant, reliable way to inform clients of errors and close the connection.

---

## How to use the new `Close` method

You can now call `Close` from within your hub methods (e.g., `OnConnected`, `OnDisconnected`, or any custom method):

```go
func (h *MyHub) OnConnected(connectionID string) {
    result, err := requestToThirdParty()
    if err != nil {
        h.Close("third party error: " + err.Error(), true) // Send error and allow reconnect
        return
    }
    // ... normal logic ...
}
```

- The client will receive a SignalR close message with your custom error.
- The connection will be closed cleanly, and the client can react accordingly.

---

## Options and Considerations

- **allowReconnect**: Set to `true` if you want the client to be able to automatically reconnect, or `false` to prevent reconnection.
- **Error message**: The error string will be visible to the client. Avoid leaking sensitive information.
- **Protocol compliance**: This approach is fully compliant with the SignalR protocol and works with all official clients.

---

## Backward Compatibility

- Existing code using `Abort()` or other connection management methods will continue to work as before.
- The new `Close` method is additive and does not break existing interfaces.

---

## Testing

- Manual and automated tests should verify that the client receives the correct close message and error, and that the connection is closed as expected.

---

## References

- [SignalR Hub Protocol Spec – Close Message](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/HubProtocol.md)

---

**This PR makes error handling and connection management more robust, user-friendly, and standards-compliant.**