### PR TITLE
fix: honor WithHTTPClient for WebSocket dial via coder/websocket DialOptions

### DIFF
--- a/httpconnection.go
+++ b/httpconnection.go
@@ -26,7 +26,10 @@ type httpConnection struct {
 }
 
 // WithHTTPClient sets the http client used to connect to the signalR server.
-// The client is only used for http requests. It is not used for the websocket connection.
+// The client is used for all HTTP requests, including the negotiate POST, the SSE downstream
+// GET, and — when the client is an *http.Client — the WebSocket upgrade handshake.
+// If the supplied Doer is not an *http.Client the WebSocket transport falls back to
+// http.DefaultClient for the dial, so custom TLS configuration is not propagated in that case.
 func WithHTTPClient(client Doer) func(*httpConnection) error {
 	return func(c *httpConnection) error {
 		c.client = client
@@ -161,6 +164,15 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 		}
 
 		opts := &websocket.DialOptions{}
+
+		// Propagate the caller-supplied client so that custom TLS configuration
+		// (e.g. a non-default root CA or InsecureSkipVerify) is honoured during
+		// the WebSocket upgrade handshake.  coder/websocket uses opts.HTTPClient
+		// for the HTTP upgrade request; its Transport must return writable bodies
+		// (http.Transport satisfies this since Go 1.12).
+		if c, ok := httpConn.client.(*http.Client); ok {
+			opts.HTTPClient = c
+		}
 
 		if httpConn.headers != nil {
 			opts.HTTPHeader = httpConn.headers()

--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -178,6 +178,37 @@ var _ = Describe("HTTP server", func() {
 })
 
 var _ = Describe("HTTP client", func() {
+	Context("WithHTTPClient over TLS", func() {
+		It("should connect via WebSocket to a TLS server using the supplied *http.Client", func(done Done) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			server, err := NewServer(ctx, SimpleHubFactory(&addHub{}), HTTPTransports(TransportWebSockets), testLoggerOption())
+			Expect(err).NotTo(HaveOccurred())
+			router := http.NewServeMux()
+			server.MapHTTP(WithHTTPServeMux(router), "/hub")
+			testServer := httptest.NewTLSServer(router)
+			defer testServer.Close()
+
+			conn, err := NewHTTPConnection(ctx, testServer.URL+"/hub",
+				WithHTTPClient(testServer.Client()),
+				WithTransports(TransportWebSockets),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			client, err := NewClient(ctx, WithConnection(conn), testLoggerOption())
+			Expect(err).NotTo(HaveOccurred())
+			client.Start()
+			Expect(<-client.WaitForState(ctx, ClientConnected)).NotTo(HaveOccurred())
+
+			result := <-client.Invoke("Add2", 1)
+			Expect(result.Error).NotTo(HaveOccurred())
+			Expect(result.Value).To(BeEquivalentTo(3))
+
+			close(done)
+		}, 5.0)
+	})
+
 	Context("WithHttpConnection", func() {
 		It("should fallback to SSE (this can only be tested when httpConnection is tampered with)", func(done Done) {
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Fixes #246.

## What changed

- `httpconnection.go`: when the caller's `Doer` is an `*http.Client`, populate `DialOptions.HTTPClient` before calling `websocket.Dial` so that `coder/websocket` uses the caller's transport for the WebSocket upgrade handshake.
- Updated `WithHTTPClient` godoc to reflect the new behaviour and document the `*http.Client` requirement for WebSocket propagation.
- `httpserver_test.go`: added a test that starts a `httptest.NewTLSServer`, connects a client with `WithHTTPClient(testServer.Client())` and `WithTransports(TransportWebSockets)`, and asserts a successful `Invoke` round-trip.

## Background

Issue #136 removed the custom client from the WebSocket path (for `nhooyr.io/websocket`) because custom transports that do not return writable response bodies broke the dial. The fix was correct for that library. Since the migration to `github.com/coder/websocket`, `DialOptions.HTTPClient` is explicitly supported and its docs note the writable-body constraint (`http.Transport` satisfies this since Go 1.12).

The type assertion (`httpConn.client.(*http.Client)`) is required because `httpConn.client` is typed as `Doer` while `DialOptions.HTTPClient` is `*http.Client`. Callers passing a non-`*http.Client` `Doer` continue to fall back to `http.DefaultClient` for the WebSocket dial, as before.