### PR TITLE
fix: clientSSEConnection.Write uses the configured Doer instead of http.DefaultClient

### DIFF
--- a/clientsseconnection.go
+++ b/clientsseconnection.go
@@ -12,12 +12,13 @@ import (
 
 type clientSSEConnection struct {
 	ConnectionBase
+	client    Doer
 	reqURL    string
 	sseReader io.Reader
 	sseWriter io.Writer
 }
 
-func newClientSSEConnection(address string, connectionID string, body io.ReadCloser) (*clientSSEConnection, error) {
+func newClientSSEConnection(address string, connectionID string, body io.ReadCloser, client Doer) (*clientSSEConnection, error) {
 	// Setup request
 	reqURL, err := url.Parse(address)
 	if err != nil {
@@ -31,6 +32,7 @@ func newClientSSEConnection(address string, connectionID string, body io.ReadClo
 			ctx:          context.Background(),
 			connectionID: connectionID,
 		},
+		client: client,
 		reqURL: reqURL.String(),
 	}
 	c.sseReader, c.sseWriter = io.Pipe()
@@ -74,8 +76,7 @@ func (c *clientSSEConnection) Write(p []byte) (n int, err error) {
 	if err != nil {
 		return 0, err
 	}
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/httpconnection.go
+++ b/httpconnection.go
@@ -196,7 +196,7 @@ func NewHTTPConnection(ctx context.Context, address string, options ...func(*htt
 			return nil, err
 		}
 
-		conn, err = newClientSSEConnection(address, negotiateResponse.ConnectionID, resp.Body)
+		conn, err = newClientSSEConnection(address, negotiateResponse.ConnectionID, resp.Body, httpConn.client)
 		if err != nil {
 			return nil, err
 		}

--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -178,6 +178,38 @@ var _ = Describe("HTTP server", func() {
 })
 
 var _ = Describe("HTTP client", func() {
+	Context("WithHTTPClient over TLS", func() {
+		It("should send messages via SSE to a TLS server using the supplied *http.Client", func(done Done) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			server, err := NewServer(ctx, SimpleHubFactory(&addHub{}), HTTPTransports(TransportServerSentEvents), testLoggerOption())
+			Expect(err).NotTo(HaveOccurred())
+			router := http.NewServeMux()
+			server.MapHTTP(WithHTTPServeMux(router), "/hub")
+			testServer := httptest.NewTLSServer(router)
+			defer testServer.Close()
+
+			conn, err := NewHTTPConnection(ctx, testServer.URL+"/hub",
+				WithHTTPClient(testServer.Client()),
+				WithTransports(TransportServerSentEvents),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			client, err := NewClient(ctx, WithConnection(conn), testLoggerOption())
+			Expect(err).NotTo(HaveOccurred())
+			client.Start()
+			Expect(<-client.WaitForState(ctx, ClientConnected)).NotTo(HaveOccurred())
+
+			// Invoke exercises the SSE Write (upstream POST) path.
+			result := <-client.Invoke("Add2", 1)
+			Expect(result.Error).NotTo(HaveOccurred())
+			Expect(result.Value).To(BeEquivalentTo(3))
+
+			close(done)
+		}, 5.0)
+	})
+
 	Context("WithHttpConnection", func() {
 		It("should fallback to SSE (this can only be tested when httpConnection is tampered with)", func(done Done) {
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Fixes #247.

## What changed

- `clientsseconnection.go`: added a `client Doer` field to `clientSSEConnection`; updated `newClientSSEConnection` to accept and store it; `Write` now calls `c.client.Do` instead of constructing `&http.Client{}`.
- `httpconnection.go`: pass `httpConn.client` to `newClientSSEConnection` at the SSE branch construction site.
- `httpserver_test.go`: added a test that starts a `httptest.NewTLSServer`, connects a client with `WithHTTPClient(testServer.Client())` and `WithTransports(TransportServerSentEvents)`, and asserts a successful `Invoke` round-trip (which exercises the upstream POST path in `Write`).

## Background

`Write` was creating a fresh `&http.Client{}` on every call. This meant a custom client passed via `WithHTTPClient` was used for the `/negotiate` POST and the SSE downstream GET, but silently dropped for the SSE upstream POST — causing `x509: certificate signed by unknown authority` errors against servers with non-system-trusted certificates even though the connection appeared to establish successfully.

This is a companion to PR #248, which fixes the same gap on the WebSocket transport path.