### PR TITLE
Align ping and timeout behavior with specification

### DIFF
--- a/loop.go
+++ b/loop.go
@@ -110,10 +110,15 @@ msgLoop:
 				break pingLoop
 			case <-keepAliveTicker.C:
 				// Send ping only when there was no write in the keepAliveInterval before
-				if time.Since(l.hubConn.LastWriteStamp()) > l.party.keepAliveInterval() {
+				nextPingIn := l.party.keepAliveInterval() - time.Since(l.hubConn.LastWriteStamp())
+
+				if nextPingIn < 100*time.Millisecond { // don't set a timer to unnecessary small values
 					if err = l.hubConn.Ping(); err != nil {
 						break pingLoop
 					}
+					keepAliveTicker.Reset(l.party.keepAliveInterval())
+				} else {
+					keepAliveTicker.Reset(nextPingIn)
 				}
 				// Don't break the pingLoop when keepAlive is over, it exists for this case
 			case <-timeoutTicker.C:

--- a/loop.go
+++ b/loop.go
@@ -114,8 +114,6 @@ msgLoop:
 						break pingLoop
 					}
 				}
-				// A successful ping or Write shows us that the connection is alive. Reset the timeout
-				timeoutTicker.Reset(l.party.timeout())
 				// Don't break the pingLoop when keepAlive is over, it exists for this case
 			case <-timeoutTicker.C:
 				err = fmt.Errorf("timeout interval elapsed (%v)", l.party.timeout())

--- a/loop.go
+++ b/loop.go
@@ -73,6 +73,7 @@ func (l *loop) Run(connected chan struct{}) (err error) {
 		}
 	}()
 	timeoutTicker := time.NewTicker(l.party.timeout())
+	keepAliveTicker := time.NewTicker(l.party.keepAliveInterval())
 msgLoop:
 	for {
 	pingLoop:
@@ -107,7 +108,7 @@ msgLoop:
 					_ = l.info.Log(evt, msgRecv, "error", err, msg, fmtMsg(evt.message), react, "close connection")
 				}
 				break pingLoop
-			case <-time.After(l.party.keepAliveInterval()):
+			case <-keepAliveTicker.C:
 				// Send ping only when there was no write in the keepAliveInterval before
 				if time.Since(l.hubConn.LastWriteStamp()) > l.party.keepAliveInterval() {
 					if err = l.hubConn.Ping(); err != nil {

--- a/loop.go
+++ b/loop.go
@@ -112,7 +112,7 @@ msgLoop:
 				// Send ping only when there was no write in the keepAliveInterval before
 				nextPingIn := l.party.keepAliveInterval() - time.Since(l.hubConn.LastWriteStamp())
 
-				if nextPingIn < 100*time.Millisecond { // don't set a timer to unnecessary small values
+				if nextPingIn <= 0 {
 					if err = l.hubConn.Ping(); err != nil {
 						break pingLoop
 					}


### PR DESCRIPTION
We're using this library to connect to the official cloud offering of SignalR (https://dotnet.microsoft.com/en-us/apps/aspnet/signalr/service). However, we were facing frequent reconnects due to ping timeouts. Unfortunately, the SignalR specification (https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/HubProtocol.md#ping-aka-keep-alive) is very vague on this topic: 

> Either endpoint may send a Ping message at any time. \[…\] Most implementations will want to reset a timeout used to determine if the other party is present.
> 
> \[…\]
> 
> The default ASP.NET Core implementation automatically pings both directions on active connections. These pings are at regular intervals, and allow detection of unexpected disconnects (for example, unplugging a server). If the client detects that the server has stopped pinging, the client will close the connection, and vice versa. If there's other traffic through the connection, keep-alive pings aren't needed. A Ping is only sent if the interval has elapsed without a message being sent.

We observe that the Microsoft managed SignalR server closes the connection to our client when 30 seconds have passed without a message being sent from the client to the server. However, our `keepAliveInterval` was configured to 5 seconds. The problem is caused by the current implementation resetting the `keepAliveInterval`\-Timer whenever a message is received. Sending pings every `keepAliveInterval` seconds and only resetting the timer when a message is sent from the client to the server (but not when a message from the server to the client is received) solved the problem.

Based on our observations we believe that the documentation could be reprahased as: “If the client detects that the server has stopped pinging, the client will close the connection, and vice versa. If the server sends other messages to the client, keep-alive pings from the server to the client aren't needed, and vice versa. A Ping is only sent from the server to the client if the interval has elapsed without a message being sent from the server to the client, and vice versa.”

Please have a look on the individual commits and on the corresponding commit messages. The commit messages explain the motivation behind every proposed change.