### PR TITLE
Set content type header for negotiate response

### DIFF
--- a/httpmux.go
+++ b/httpmux.go
@@ -247,6 +247,7 @@ func (h *httpMux) negotiate(w http.ResponseWriter, req *http.Request) {
 			AvailableTransports: availableTransports,
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(response) // Can't imagine an error when encoding
 	}

--- a/httpserver_test.go
+++ b/httpserver_test.go
@@ -255,6 +255,7 @@ func negotiateWebSocketTestServer(port int) map[string]interface{} {
 	resp, err := http.Post(fmt.Sprintf("http://127.0.0.1:%v/hub/negotiate", port), "text/plain;charset=UTF-8", &buf)
 	Expect(err).To(BeNil())
 	Expect(resp).ToNot(BeNil())
+	Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
 	defer func() {
 		_ = resp.Body.Close()
 	}()


### PR DESCRIPTION
This fixes #254 by setting the `Content-Type` header in the response from the `negotiate` endpoint.